### PR TITLE
Add metrics to blob worker

### DIFF
--- a/fdbclient/BlobGranuleReader.actor.cpp
+++ b/fdbclient/BlobGranuleReader.actor.cpp
@@ -253,6 +253,8 @@ static void applyDeltas(std::map<KeyRef, ValueRef>* dataMap,
 	}
 }
 
+// TODO: improve the interface of this function so that it doesn't need 
+//       to be passed the entire BlobWorkerStats object
 ACTOR Future<RangeResult> readBlobGranule(BlobGranuleChunkRef chunk,
                                           KeyRangeRef keyRange,
                                           Version readVersion,

--- a/fdbclient/BlobGranuleReader.actor.cpp
+++ b/fdbclient/BlobGranuleReader.actor.cpp
@@ -256,7 +256,9 @@ static void applyDeltas(std::map<KeyRef, ValueRef>* dataMap,
 ACTOR Future<RangeResult> readBlobGranule(BlobGranuleChunkRef chunk,
                                           KeyRangeRef keyRange,
                                           Version readVersion,
-                                          Reference<BackupContainerFileSystem> bstore) {
+                                          Reference<BackupContainerFileSystem> bstore,
+                                          Optional<BlobWorkerStats *> stats) {
+
 	// TODO REMOVE with V2 of protocol
 	ASSERT(readVersion == chunk.includedVersion);
 	// Arena to hold all allocations for applying deltas. Most of it, and the arenas produced by reading the files,
@@ -269,13 +271,23 @@ ACTOR Future<RangeResult> readBlobGranule(BlobGranuleChunkRef chunk,
 	try {
 		state std::map<KeyRef, ValueRef> dataMap;
 
-		Future<Arena> readSnapshotFuture = chunk.snapshotFile.present()
-		                                       ? readSnapshotFile(bstore, chunk.snapshotFile.get(), keyRange, &dataMap)
-		                                       : Future<Arena>(Arena());
+		Future<Arena> readSnapshotFuture;
+		if (chunk.snapshotFile.present()) {
+			readSnapshotFuture = readSnapshotFile(bstore, chunk.snapshotFile.get(), keyRange, &dataMap);
+			if (stats.present()) {
+				++stats.get()->s3GetReqs;
+			}
+		} else {
+			readSnapshotFuture = Future<Arena>(Arena());
+		}
+
 		state std::vector<Future<Standalone<GranuleDeltas>>> readDeltaFutures;
 		readDeltaFutures.reserve(chunk.deltaFiles.size());
 		for (BlobFilenameRef deltaFile : chunk.deltaFiles) {
 			readDeltaFutures.push_back(readDeltaFile(bstore, deltaFile, keyRange, readVersion));
+			if (stats.present()) {
+				++stats.get()->s3GetReqs;
+			}
 		}
 
 		Arena snapshotArena = wait(readSnapshotFuture);

--- a/fdbclient/BlobGranuleReader.actor.h
+++ b/fdbclient/BlobGranuleReader.actor.h
@@ -30,6 +30,7 @@
 
 #include "fdbclient/BlobWorkerInterface.h"
 #include "fdbclient/BackupContainerFileSystem.h"
+#include "fdbclient/BlobWorkerCommon.h"
 
 #include "flow/actorcompiler.h" // This must be the last #include.
 
@@ -38,7 +39,8 @@
 ACTOR Future<RangeResult> readBlobGranule(BlobGranuleChunkRef chunk,
                                           KeyRangeRef keyRange,
                                           Version readVersion,
-                                          Reference<BackupContainerFileSystem> bstore);
+                                          Reference<BackupContainerFileSystem> bstore,
+                                          Optional<BlobWorkerStats *> stats=Optional<BlobWorkerStats *>());
 
 ACTOR Future<Void> readBlobGranules(BlobGranuleFileRequest request,
                                     BlobGranuleFileReply reply,

--- a/fdbclient/BlobWorkerCommon.h
+++ b/fdbclient/BlobWorkerCommon.h
@@ -30,11 +30,10 @@ struct BlobWorkerStats {
 	Counter deltaBytesWritten, snapshotBytesWritten;
 	Counter bytesReadFromFDBForInitialSnapshot;
 	Counter bytesReadFromS3ForCompaction;
-	Counter rangeAssignmentRequests;
-	Counter readRequests;
+	Counter rangeAssignmentRequests, readRequests;
 	Counter wrongShardServer;
-	Counter rangeFeedInputBytes, rangeFeedOutputBytes;
-	Counter readReqTotalFilesReturned, readReqDeltaFilesReturned;
+	Counter changeFeedInputBytes;
+	Counter readReqTotalFilesReturned;
 	Counter readReqDeltaBytesReturned;
 
 	int numRangesAssigned;
@@ -53,8 +52,8 @@ struct BlobWorkerStats {
 		bytesReadFromS3ForCompaction("BytesReadFromS3ForCompaction", cc),
 		rangeAssignmentRequests("RangeAssignmentRequests", cc), readRequests("ReadRequests", cc),
 		wrongShardServer("WrongShardServer", cc),
-		rangeFeedInputBytes("RangeFeedInputBytes", cc), rangeFeedOutputBytes("RangeFeedOutputBytes", cc),
-		readReqTotalFilesReturned("ReadReqTotalFilesReturned", cc), readReqDeltaFilesReturned("ReadReqDeltaFilesReturned", cc),
+		changeFeedInputBytes("RangeFeedInputBytes", cc),
+		readReqTotalFilesReturned("ReadReqTotalFilesReturned", cc),
 		readReqDeltaBytesReturned("ReadReqDeltaBytesReturned", cc),
 		numRangesAssigned(0), mutationBytesBuffered(0)
 	{

--- a/fdbclient/BlobWorkerCommon.h
+++ b/fdbclient/BlobWorkerCommon.h
@@ -1,0 +1,68 @@
+/*
+ * BlobWorkerCommon.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FDBCLIENT_BLOBWORKERCOMMON_H
+#define FDBCLIENT_BLOBWORKERCOMMON_H
+
+#include "fdbrpc/Stats.h"
+
+struct BlobWorkerStats {
+	CounterCollection cc;
+	Counter s3PutReqs, s3GetReqs, s3DeleteReqs;
+	Counter deltaFilesWritten, snapshotFilesWritten;
+	Counter deltaBytesWritten, snapshotBytesWritten;
+	Counter bytesReadFromFDBForInitialSnapshot;
+	Counter bytesReadFromS3ForCompaction;
+	Counter rangeAssignmentRequests;
+	Counter readRequests;
+	Counter wrongShardServer;
+	Counter rangeFeedInputBytes, rangeFeedOutputBytes;
+	Counter readReqTotalFilesReturned, readReqDeltaFilesReturned;
+	Counter readReqDeltaBytesReturned;
+
+	int numRangesAssigned;
+	int mutationBytesBuffered;
+
+	Future<Void> logger;
+
+	// Current stats maintained for a given blob worker process
+	explicit BlobWorkerStats(UID id, double interval)
+	  : cc("BlobWorkerStats", id.toString()),
+
+		s3PutReqs("S3PutReqs", cc), s3GetReqs("S3GetReqs", cc), s3DeleteReqs("S3DeleteReqs", cc),
+		deltaFilesWritten("DeltaFilesWritten", cc), snapshotFilesWritten("SnapshotFilesWritten", cc),
+		deltaBytesWritten("DeltaBytesWritten", cc), snapshotBytesWritten("SnapshotBytesWritten", cc),
+		bytesReadFromFDBForInitialSnapshot("BytesReadFromFDBForInitialSnapshot", cc),
+		bytesReadFromS3ForCompaction("BytesReadFromS3ForCompaction", cc),
+		rangeAssignmentRequests("RangeAssignmentRequests", cc), readRequests("ReadRequests", cc),
+		wrongShardServer("WrongShardServer", cc),
+		rangeFeedInputBytes("RangeFeedInputBytes", cc), rangeFeedOutputBytes("RangeFeedOutputBytes", cc),
+		readReqTotalFilesReturned("ReadReqTotalFilesReturned", cc), readReqDeltaFilesReturned("ReadReqDeltaFilesReturned", cc),
+		readReqDeltaBytesReturned("ReadReqDeltaBytesReturned", cc),
+		numRangesAssigned(0), mutationBytesBuffered(0)
+	{
+		specialCounter(cc, "NumRangesAssigned", [this]() { return this->numRangesAssigned; });
+		specialCounter(cc, "MutationBytesBuffered", [this]() { return this->mutationBytesBuffered; });
+
+		logger = traceCounters("BlobWorkerMetrics", id, interval, &cc, "BlobWorkerMetrics");
+	}
+};
+
+#endif

--- a/fdbclient/CMakeLists.txt
+++ b/fdbclient/CMakeLists.txt
@@ -21,6 +21,7 @@ set(FDBCLIENT_SRCS
   BlobGranuleReader.actor.cpp
   BlobGranuleReader.actor.h
   BlobGranuleCommon.h
+  BlobWorkerCommon.h
   ClientKnobCollection.cpp
   ClientKnobCollection.h
   ClientKnobs.cpp

--- a/fdbserver/BlobWorker.actor.cpp
+++ b/fdbserver/BlobWorker.actor.cpp
@@ -217,8 +217,9 @@ ACTOR Future<BlobFileIndex> writeDeltaFile(BlobWorkerData* bwData,
 		if (BW_DEBUG) {
 			printf("deleting s3 delta file %s after error %s\n", fname.c_str(), e.name());
 		}
-		bwData->bstore->deleteFile(fname);
-		throw e;
+		state Error eState = e;
+		wait(bwData->bstore->deleteFile(fname));
+		throw eState;
 	}
 }
 
@@ -304,8 +305,9 @@ ACTOR Future<BlobFileIndex> writeSnapshot(BlobWorkerData* bwData,
 		if (BW_DEBUG) {
 			printf("deleting s3 snapshot file %s after error %s\n", fname.c_str(), e.name());
 		}
-		bwData->bstore->deleteFile(fname);
-		throw e;
+		state Error eState = e;
+		wait(bwData->bstore->deleteFile(fname));
+		throw eState;
 	}
 
 	if (BW_DEBUG) {


### PR DESCRIPTION
# Summary
We want to add metrics for the blob worker to evaluate its
performance more concretely. We decided to track the following
information:

- s3 put requests
- s3 get requests
- S3 delete requests
- Delta files written
- Snapshot files written
- Delta bytes written
- Snapshot bytes written
- Number of current ranges assigned
- Bytes read from FDB (initial snapshot)
- Bytes read from S3 (compaction)
- Read requests count
- Read files returned
- Read deltas returned
- Read delta bytes returned
- Ranges assigned
- Ranges revoked
- Number of current ranges assigned
- Total mutation bytes buffered across all ranges // current or accumulated
- Range feed bytes input
- Range feed mutations input
- Wrong Shard Server count

# Testing
- [ ] Ensure metrics show up in trace logfiles under label `BlobWorkerMetrics` and make sense
- [ ] Hybrid simulation test succeeds

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
