### PR TITLE
Added blob granule splitting

### DIFF
--- a/fdbclient/BlobGranuleCommon.h
+++ b/fdbclient/BlobGranuleCommon.h
@@ -108,4 +108,5 @@ struct BlobGranuleChunkRef {
 	}
 };
 
+enum BlobGranuleSplitState { Unknown = 0, Started = 1, Assigned = 2, Done = 3 };
 #endif

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -6581,7 +6581,7 @@ Future<Standalone<VectorRef<MutationsAndVersionRef>>> DatabaseContext::getRangeF
 
 ACTOR Future<Void> getRangeFeedStreamActor(Reference<DatabaseContext> db,
                                            PromiseStream<Standalone<VectorRef<MutationsAndVersionRef>>> results,
-                                           StringRef rangeID,
+                                           Key rangeID,
                                            Version begin,
                                            Version end,
                                            KeyRange range) {

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -752,10 +752,13 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	// Blob granlues
 	init( BG_URL,                                                 "" );
 	// TODO CHANGE BACK
-	init( BG_SNAPSHOT_FILE_TARGET_BYTES,                    10000000 );
-	// init( BG_SNAPSHOT_FILE_TARGET_BYTES,                    1000000 );
+	// init( BG_SNAPSHOT_FILE_TARGET_BYTES,                    10000000 );
+	init( BG_SNAPSHOT_FILE_TARGET_BYTES,                    1000000 );
 	init( BG_DELTA_BYTES_BEFORE_COMPACT, BG_SNAPSHOT_FILE_TARGET_BYTES/2 );
 	init( BG_DELTA_FILE_TARGET_BYTES,   BG_DELTA_BYTES_BEFORE_COMPACT/10 );
+
+	// TODO should discuss proper value for this
+	init( BLOB_WORKER_TIMEOUT,                                   10.0 ); if( randomize && BUGGIFY ) BLOB_WORKER_TIMEOUT = 1.0;
 
 	// clang-format on
 

--- a/fdbclient/ServerKnobs.h
+++ b/fdbclient/ServerKnobs.h
@@ -704,6 +704,8 @@ public:
 	int BG_DELTA_FILE_TARGET_BYTES;
 	int BG_DELTA_BYTES_BEFORE_COMPACT;
 
+	double BLOB_WORKER_TIMEOUT; // Blob Manager's reaction time to a blob worker failure
+
 	ServerKnobs(Randomize, ClientKnobs*, IsSimulated);
 	void initialize(Randomize, ClientKnobs*, IsSimulated);
 };

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -1104,6 +1104,7 @@ int64_t decodeBlobManagerEpochValue(ValueRef const& value) {
 const KeyRangeRef blobGranuleFileKeys(LiteralStringRef("\xff\x02/bgf/"), LiteralStringRef("\xff\x02/bgf0"));
 const KeyRangeRef blobGranuleMappingKeys(LiteralStringRef("\xff\x02/bgm/"), LiteralStringRef("\xff\x02/bgm0"));
 const KeyRangeRef blobGranuleLockKeys(LiteralStringRef("\xff\x02/bgl/"), LiteralStringRef("\xff\x02/bgl0"));
+const KeyRangeRef blobGranuleSplitKeys(LiteralStringRef("\xff\x02/bgs/"), LiteralStringRef("\xff\x02/bgs0"));
 
 const Value blobGranuleMappingValueFor(UID const& workerID) {
 	BinaryWriter wr(Unversioned());
@@ -1118,19 +1119,35 @@ UID decodeBlobGranuleMappingValue(ValueRef const& value) {
 	return workerID;
 }
 
-const Value blobGranuleLockValueFor(int64_t epoch, int64_t seqno) {
+const Value blobGranuleLockValueFor(int64_t epoch, int64_t seqno, UID changeFeedId) {
 	BinaryWriter wr(Unversioned());
 	wr << epoch;
 	wr << seqno;
+	wr << changeFeedId;
 	return wr.toValue();
 }
 
-std::pair<int64_t, int64_t> decodeBlobGranuleLockValue(const ValueRef& value) {
+std::tuple<int64_t, int64_t, UID> decodeBlobGranuleLockValue(const ValueRef& value) {
 	int64_t epoch, seqno;
+	UID changeFeedId;
 	BinaryReader reader(value, Unversioned());
 	reader >> epoch;
 	reader >> seqno;
-	return std::pair(epoch, seqno);
+	reader >> changeFeedId;
+	return std::make_tuple(epoch, seqno, changeFeedId);
+}
+
+const Value blobGranuleSplitValueFor(BlobGranuleSplitState st) {
+	BinaryWriter wr(Unversioned());
+	wr << st;
+	return wr.toValue();
+}
+
+BlobGranuleSplitState decodeBlobGranuleSplitValue(const ValueRef& value) {
+	BlobGranuleSplitState st;
+	BinaryReader reader(value, Unversioned());
+	reader >> st;
+	return st;
 }
 
 const KeyRangeRef blobWorkerListKeys(LiteralStringRef("\xff\x02/bwList/"), LiteralStringRef("\xff\x02/bwList0"));

--- a/fdbclient/SystemData.h
+++ b/fdbclient/SystemData.h
@@ -25,7 +25,7 @@
 // Functions and constants documenting the organization of the reserved keyspace in the database beginning with "\xFF"
 
 #include "fdbclient/FDBTypes.h"
-#include "fdbclient/BlobWorkerInterface.h" // TODO move the functions that depend on this out of here and into BlobWorkerInterface.h
+#include "fdbclient/BlobWorkerInterface.h" // TODO move the functions that depend on this out of here and into BlobWorkerInterface.h to remove this depdendency
 #include "fdbclient/StorageServerInterface.h"
 
 // Don't warn on constants being defined in this file.
@@ -535,16 +535,23 @@ extern const KeyRangeRef blobGranuleFileKeys;
 // \xff/bgm/[[begin]] = [[BlobWorkerUID]]
 extern const KeyRangeRef blobGranuleMappingKeys;
 
-// \xff/bgl/(begin,end) = (epoch, seqno)
+// \xff/bgl/(begin,end) = (epoch, seqno, changefeed id)
 extern const KeyRangeRef blobGranuleLockKeys;
 
-const Value blobGranuleLockValueFor(int64_t epochNum, int64_t sequenceNum);
-std::pair<int64_t, int64_t> decodeBlobGranuleLockValue(ValueRef const& value);
+// \xff/bgs/(oldbegin,oldend,newbegin) = state
+extern const KeyRangeRef blobGranuleSplitKeys;
 
 const Value blobGranuleMappingValueFor(UID const& workerID);
 UID decodeBlobGranuleMappingValue(ValueRef const& value);
 
-// \xff/blobWorkerList/[[BlobWorkerID]] = [[BlobWorkerInterface]]
+const Value blobGranuleLockValueFor(int64_t epochNum, int64_t sequenceNum, UID changeFeedId);
+// FIXME: maybe just define a struct?
+std::tuple<int64_t, int64_t, UID> decodeBlobGranuleLockValue(ValueRef const& value);
+
+const Value blobGranuleSplitValueFor(BlobGranuleSplitState st);
+BlobGranuleSplitState decodeBlobGranuleSplitValue(ValueRef const& value);
+
+// \xff/bwl/[[BlobWorkerID]] = [[BlobWorkerInterface]]
 extern const KeyRangeRef blobWorkerListKeys;
 
 const Key blobWorkerListKeyFor(UID workerID);

--- a/tests/slow/BlobGranuleCorrectnessLarge.toml
+++ b/tests/slow/BlobGranuleCorrectnessLarge.toml
@@ -1,0 +1,21 @@
+[[test]]
+testTitle = 'BlobGranuleCorrectnessTestLarge'
+
+    [[test.workload]]
+    testName = 'ReadWrite'
+    testDuration = 200.0
+    transactionsPerSecond = 1000
+    writesPerTransactionA = 0
+    readsPerTransactionA = 10
+    writesPerTransactionB = 10
+    readsPerTransactionB = 1
+    alpha = 0.5
+    nodeCount = 2000000
+    valueBytes = 128
+    discardEdgeMeasurements = false
+    warmingDelay = 10.0
+    setup = false
+
+    [[test.workload]]
+    testName = 'BlobGranuleVerifier'
+    testDuration = 200.0


### PR DESCRIPTION
Added granule splitting, which turned out to be decently complicated.
Blob workers still do not handle reassigning an existing range, I will handle that in a later PR.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
